### PR TITLE
Completing and testing of update community image

### DIFF
--- a/IBMConnections2/ICCommunities.html
+++ b/IBMConnections2/ICCommunities.html
@@ -224,6 +224,11 @@
                document.querySelector("#communityRow").style.display = "inline";
                document.querySelector("#userRoleRow").style.display = "none";
                break;
+            case "ChangeImage" :
+               document.querySelector("#userRow").style.display = "none";
+               document.querySelector("#communityRow").style.display = "inline";
+               document.querySelector("#userRoleRow").style.display = "none";
+               break;
        }
    }
 </script>
@@ -238,7 +243,8 @@
         <label for="node-input-target"><i class="fa fa-arrow-circle-right"></i> Search</label>
         <select id="node-input-target" onchange="updateFormCommunitiesUpdate()">
 	       <option value="AddMember">Add Member</option>
-	       <option value="RemoveMember">Remove Member</option>
+           <option value="RemoveMember">Remove Member</option>
+           <option value="ChangeImage">Change Community Image</option>
         </select>
         <br />
     </div>
@@ -282,6 +288,7 @@
    The configuration panel can override or replace this value</li>
    <li><code>msg.communityId</code> : the ID of the Community to which the member needs to be added or removed.<br/>
    The configuration panel can override or replace this value</li>
+   <li><code>msg.communityImage</code> : the raw image to upload. <b>NOTE : </b> relevant only for changing the community image, currently only PNG is supported</b></li>
    </ul></p>
    <p><i>Returns:</i>
    <ul>

--- a/IBMConnections2/ICCommunities.js
+++ b/IBMConnections2/ICCommunities.js
@@ -356,6 +356,36 @@ module.exports = function (RED) {
             );
         }
 
+        function changeImage(theMsg, theURL, commId, image) {
+            node.login.request({
+                url: theURL,
+                method: "PUT",
+                body: image,
+                headers: {"Content-Type": "image/png"}
+            },
+            function (error, response, body) {
+                if (error) {
+                    console.log("changeCommunityImage : error changing image");
+                    node.status({fill: "red", shape: "dot", text: "error changing image"});
+                    node.error(error.toString(), theMsg);
+                } else {
+                    console.log('changeCommunityImage: run');
+                    if ((response.statusCode >= 200) && (response.statusCode < 300)) {
+                        console.log("changeCommunityImage OK (" + response.statusCode + ")");
+                        console.log(body);
+                        node.status({});
+                        node.send(theMsg);
+                    } else {
+                        console.log("changeCommunityImage NOT OK (" + response.statusCode + ")");
+                        console.log(body);
+                        console.log(theURL);
+                        node.status({fill: "red", shape: "dot", text: "Err3 " + response.statusMessage});
+                        node.error(response.statusCode + ' : ' + response.statusMessage, theMsg);
+                    }
+                }
+            });
+        }
+
         this.on(
             'input',
             function (msg) {
@@ -390,22 +420,38 @@ module.exports = function (RED) {
                 //  Check if the user to be added/removed is specified
                 //
                 var userId = '';
-                if ((config.email == '') &&
-                    ((msg.userId == undefined) || (msg.userId == ''))) {
-                    //
-                    //  There is an issue
-                    //
-                    console.log("Missing UserId Information");
-                    node.status({ fill: "red", shape: "dot", text: "Missing UserId" });
-                    node.error('Missing UserId', msg);
-                    return;
-                } else {
-                    if (config.userId != '') {
-                        userId = config.userId.trim();
+                var communityImage = '';
+                if (config.target === "AddMember" || config.target ==="RemoveMember") {
+                    if ((config.email == '') &&
+                        ((msg.userId == undefined) || (msg.userId == ''))) {
+                        //
+                        //  There is an issue
+                        //
+                        console.log("Missing UserId Information");
+                        node.status({ fill: "red", shape: "dot", text: "Missing UserId" });
+                        node.error('Missing UserId', msg);
+                        return;
                     } else {
-                        userId = msg.userId.trim();
+                        if (config.userId != '') {
+                            userId = config.userId.trim();
+                        } else {
+                            userId = msg.userId.trim();
+                        }
+                    }
+                } else {
+                    if ((msg.communityImage == undefined || msg.communityImage == '')) {
+                        //
+                        //  There is an issue
+                        //
+                        console.log("Missing communityImage Information");
+                        node.status({fill: "red", shape: "dot", text: "Missing communityImage"});
+                        node.error('Missing communityImage', msg);
+                        return;
+                    } else {
+                        communityImage = msg.communityImage;
                     }
                 }
+            
                 //
                 //  Initialize the display
                 //
@@ -447,6 +493,10 @@ module.exports = function (RED) {
                         // remove Member
                         //
                         removeCommunityMember(msg, myURL);
+                        break;
+                    case "ChangeImage":
+                        myURL += "/service/html/image?communityUuid=" + communityId;
+                        changeImage(msg, myURL, communityId, communityImage);
                         break;
                 }
             }


### PR DESCRIPTION
I'm not sure how to cross-reference the file-type of the file passed with a drop-down of image types. So at the moment it's hard-coded to just use PNGs. The image type gets added to the Content-Type header. Sending a base64-encoded image doesn't seem to be supported by Connections (I tried from Postman too), just the file itself.

Sample flow below
![screenshot](https://user-images.githubusercontent.com/3721367/54752759-1aba9c80-4bd7-11e9-9849-a2c14cea9a0b.png)
